### PR TITLE
   partial paths for whitelist urls

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,25 @@ function my_forcelogin_whitelist() {
 add_filter('v_forcelogin_whitelist', 'my_forcelogin_whitelist', 10, 1);
 `
 
+= How can I add exceptions for certain base paths? =
+
+You can specify an array of URLs to whitelist by adding the following filter to your functions.php file. Each URL must be absolute (as in, http://example.com/mypage/). Recommended: site_url( '/mypage/' ).
+
+`
+/**
+ * Filter Force Login to allow exceptions for specific URLs.
+ *
+ * @return array An array of partial paths starting from the base path
+ **/
+function my_forcelogin_whitelist_path() {
+  return array(
+    site_url( '/wp-json/frm/forms/' ),
+    site_url( '/wp-json/frm/entries/' )
+  );
+}
+add_filter('v_forcelogin_whitelist_path', 'my_forcelogin_whitelist', 10, 1);
+`
+
 
 == Changelog ==
 


### PR DESCRIPTION
So I am using 
https://formidablepro.com/knowledgebase/formidable-api/
and it had api urls in the form at the bottom.  We are linking in from another application with shared auth (CAS) and require the user be logged in to access some forms using your plugin for this requirment.  We extract the data using formidables api and this is where the issue lies.  We can add white list entries for each set or form apis but it will be a pain to manage.   This adds base path filters to allow api access to the form apis.


 * yoursite.com/wp-json/frm/forms GET Get a list of forms
 * yoursite.com/wp-json/frm/forms POST Create a form
 * yoursite.com/wp-json/frm/forms/5 GET Get form #5 (Change 5 to the ID of your form)
 * yoursite.com/wp-json/frm/forms/5 DELETE Permanently delete form #5 (Change 5 to the ID of your form)
 * yoursite.com/wp-json/frm/forms/5/html GET Get the form HTML to display on a page
 * yoursite.com/wp-json/frm/forms/5/fields GET Get an array of fields from form #5
 * yoursite.com/wp-json/frm/forms/5/entries GET Get the entries from form #5
 * yoursite.com/wp-json/frm/forms/5/entries DELETE Delete the entries from form #5
 * yoursite.com/wp-json/frm/entries POST Create an entry
 * yoursite.com/wp-json/frm/entries/25 GET Get entry #25 in an array
 * yoursite.com/wp-json/frm/entries/25 POST/PUT/PATCH Update entry #25
 * yoursite.com/wp-json/frm/entries/25 DELETE Delete entry #25